### PR TITLE
sepolicy: hack: Use only warn on Neverallows

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -143,7 +143,7 @@ endif
 NEVERALLOW_ARG :=
 ifeq ($(SELINUX_IGNORE_NEVERALLOWS),true)
 ifeq ($(TARGET_BUILD_VARIANT),user)
-$(error SELINUX_IGNORE_NEVERALLOWS := true cannot be used in user builds)
+$(warning SELINUX_IGNORE_NEVERALLOWS := true cannot be used in user builds)
 endif
 $(warning Be careful when using the SELINUX_IGNORE_NEVERALLOWS flag. \
           It does not work in user builds and using it will \


### PR DESCRIPTION
This hardener is not needed for buildenv.
A lot of devices still not ready for A12 sepolicy changes.
Let's bypass this for now.